### PR TITLE
Don't show a blank error message clause

### DIFF
--- a/lib/Data/Processor/Validator.pm
+++ b/lib/Data/Processor/Validator.pm
@@ -197,7 +197,13 @@ sub _check_mandatory_keys{
             my $error_msg = '';
             $error_msg = $self->{schema}->{$key}->{error_msg}
                 if $self->{schema}->{$key}->{error_msg};
-            $self->error("mandatory key '$key' missing. Error msg: '$error_msg'");
+
+            my $error_clause = '';
+            if( $error_msg ){
+                $error_clause = " Error msg: '$error_msg'";
+            }
+
+            $self->error("mandatory key '$key' missing.".$error_clause);
         }
         else{
             $self->explain("false\n");

--- a/t/002_validate.t
+++ b/t/002_validate.t
@@ -75,6 +75,28 @@ ok ($error_collection->any_error_contains(
     'correct error msg'
 );
 
+subtest 'Errors with no error message drop the error message clause' => sub{
+    my $nem_schema = {
+        x => {
+            value => qr{x},
+        },
+        y => {
+            value => qr{y},
+            error_msg => 'Oh dear',
+        },
+    };
+    my $nem_processor = Data::Processor->new(
+        $nem_schema
+    );
+    my $ec = $nem_processor->validate({});
+    is( $ec->count, 2, 'Get two errors');
+    my @nem_errors = $ec->as_array;
+    my ($xerr) = grep{/\'x\'/} @nem_errors;
+    my ($yerr) = grep{/\'y\'/} @nem_errors;
+    unlike($xerr, qr{Error msg:}, 'No error message clause on the x error');
+    like($yerr, qr{Error msg:}, 'Error message clause on the y error');
+};
+
 done_testing;
 
 sub data {


### PR DESCRIPTION
Hi.

Loving this module!

But a small niggle. Often I get an error message like this:

 mandatory key 'y' missing. Error msg: ''

So I created a quick patch to exclude this situation, so if there is an error message part to show there it is still shown but otherwise you just get:

 mandatory key 'y' missing

Thanks!