### PR TITLE
FIX: documentation spilling into code examples

### DIFF
--- a/lib/Data/Processor.pm
+++ b/lib/Data/Processor.pm
@@ -420,7 +420,7 @@ Obviously this can be nested all the way down:
 
 =head2 array
 
- To have a key point to an array of things, simply use the array key. So:
+To have a key point to an array of things, simply use the array key. So:
 
  my $schema = {
     houses => {
@@ -428,11 +428,11 @@ Obviously this can be nested all the way down:
     }
  };
 
- Would describe a structure like:
+Would describe a structure like:
 
  { houses => [] }
 
- And of course you can nest within here so:
+And of course you can nest within here so:
 
  my $schema = {
     houses => {
@@ -446,7 +446,7 @@ Obviously this can be nested all the way down:
     },
  };
 
- Might describe:
+Might describe:
 
  {
    houses => [


### PR DESCRIPTION
Extremely non-urgent, but I noticed some formatting issues when I looked at my documentation additions on meta-cpan, in that my text had accidentally ended up in the code blocks for the "array" section. This request fixes that!
