### PR TITLE
support storing metadata in the schema

### DIFF
--- a/lib/Data/Processor.pm
+++ b/lib/Data/Processor.pm
@@ -232,6 +232,11 @@ sub validate_schema {
                     validator => sub {
                         ref shift eq 'CODE' ? undef : 'expected a callback'
                     }
+                },
+                'x-.+' => {
+                    optional => 1,
+                    regex => 1,
+                    description => 'metadata'
                 }
             }
         }
@@ -327,6 +332,16 @@ sub merge_schema {
     $mergeSubSchema->($mergeNode, $schema);
 
     return $self->validate_schema;
+}
+
+=head2 schema
+
+Returns the schema. Useful after schema merging.
+
+=cut
+
+sub schema{
+    return shift->{schema};
 }
 
 =head2 transform_data

--- a/t/002_validate.t
+++ b/t/002_validate.t
@@ -121,6 +121,7 @@ sub schema {
         GENERAL => {
             description => 'general settings',
             error_msg   => 'Section GENERAL missing',
+            'x-meta'    => 'metadata',
             members => {
                 logfile => {
                     value       => qr{/.*},


### PR DESCRIPTION
I have a use case where I need to store additional information in the schema. These properties (prefixed with `x-`) shall be ignored by the validator but the schema checker should accept it.