### PR TITLE
add allow_empty option for arrays

### DIFF
--- a/lib/Data/Processor.pm
+++ b/lib/Data/Processor.pm
@@ -198,6 +198,16 @@ sub validate_schema {
                     default => 0,
                     validator => $bool
                 },
+                allow_empty => {
+                    description => 'allow empty entries in an array',
+                    optional => 1,
+                    default => 0,
+                    validator => sub {
+                        my ($value, $parent) = @_;
+                        return 'allow_empty can only be set for array' if !$parent->{array};
+                        return $value =~ /^[01]$/ ? undef : 'Expected 0 or 1';
+                    }
+                },
                 members => {
                     description => 'what keys do I expect in a hash hanging off this key',
                     optional => 1,

--- a/lib/Data/Processor/Validator.pm
+++ b/lib/Data/Processor/Validator.pm
@@ -101,6 +101,9 @@ sub validate {
             $self->explain(
             ">>'$key' is an array reference so we check all elements\n");
             for my $member (@{$self->{data}->{$key}}){
+                next if !defined $member
+                    && $self->{schema}->{$schema_key}->{allow_empty};
+
                 my $e = Data::Processor::Validator->new(
                     $self->{schema}->{$schema_key}->{members},
                     parent_keys => [@{$self->{parent_keys}}, $key],

--- a/t/013_array.t
+++ b/t/013_array.t
@@ -6,6 +6,7 @@ use Data::Processor;
 my $schema = {
     array => {
         array => 1,
+        allow_empty => 1,
         members => {
             one => {
                 value => qr{what.*}
@@ -45,6 +46,7 @@ my $data = {
             one => 'whatever',
             two => 'something else'
         },
+        undef,
         {
             'error: members missing',
         },


### PR DESCRIPTION
I have a use-case where the array index matters; elements must not be moved but there could be "empty" array members in between of other members. something like this:

```
   "disk" : [
      {
         "block_size" : "8K",
         "disk_path" : "data/vm/r151032-build/data",
         "disk_size" : "60G",
         "sparse" : "false"
      },
      null,
      {
         "block_size" : "8K",
         "disk_path" : "data/vm/r151032-build/data-test",
         "disk_size" : "10G",
         "sparse" : "false"
      }
   ],
```

this commit is adding a new property `allow_empty` which can be used for arrays and will allow empty array elements.