### PR TITLE
transform all values for keys on the same level before validating

### DIFF
--- a/lib/Data/Processor.pm
+++ b/lib/Data/Processor.pm
@@ -153,12 +153,12 @@ sub validate_schema {
                 description => {
                     description => 'the description of this content of this key',
                     optional => 1,
-                    validator => $vf->rx(qr(.+),'expected a description string'),
+                    validator => $vf->rx(qr(^.+$),'expected a description string'),
                 },
                 example => {
                     description => 'an example value for this key',
                     optional => 1,
-                    validator => $vf->rx(qr(.+),'expected an example string'),
+                    validator => $vf->rx(qr(^.+$),'expected an example string'),
                 },
                 no_descend_into => {
                     optional => 1,
@@ -180,7 +180,7 @@ sub validate_schema {
                 error_msg => {
                     description => 'an error message for the case that the value regexp does not match',
                     optional => 1,
-                    validator => $vf->rx(qr(.+),'expected an error message string'),
+                    validator => $vf->rx(qr(^.+$),'expected an error message string'),
                 },
                 optional => {
                     description => 'is this key optional ?',
@@ -205,8 +205,13 @@ sub validate_schema {
                     validator => sub {
                         my ($value, $parent) = @_;
                         return 'allow_empty can only be set for array' if !$parent->{array};
-                        return $value =~ /^[01]$/ ? undef : 'Expected 0 or 1';
+                        return $bool->($value);
                     }
+                },
+                order => {
+                    description => 'numeric value to specify the validation order',
+                    optional => 1,
+                    validator => $vf->rx(qr(^\d+$), 'expected an integer'),
                 },
                 members => {
                     description => 'what keys do I expect in a hash hanging off this key',

--- a/lib/Data/Processor/Validator.pm
+++ b/lib/Data/Processor/Validator.pm
@@ -50,7 +50,18 @@ sub validate {
 
     $self->_add_defaults_and_transform();
 
-    for my $key (keys %{$self->{data}}){
+    my $order = sub {
+        my ($a, $b) = @_;
+
+        return 1 if !$self->{schema_keys}->{$a}
+            || !$self->{schema}->{$self->{schema_keys}->{$a}}->{order};
+        return -1 if !$self->{schema_keys}->{$b}
+            || !$self->{schema}->{$self->{schema_keys}->{$b}}->{order};
+        return $self->{schema}->{$self->{schema_keys}->{$a}}->{order}
+            <=> $self->{schema}->{$self->{schema_keys}->{$b}}->{order};
+    };
+
+    for my $key (sort { $order->($a, $b) } keys %{$self->{data}}) {
         $self->explain (">>'$key'");
 
         my $schema_key = $self->{schema_keys}->{$key} or next;


### PR DESCRIPTION
validators can depend on the value of "neighbouring" keys; to have a consistent state we should transform all values for keys on the same level before starting to validate.

with this fix we can get rid of workarounds in `zadm` that need to (re-)run the transformer in validators since it's unknown whether the neighbouring value was already transformed or not:
https://github.com/omniosorg/zadm/pull/88/commits/bee7921941f30320b543970590e42f0724357d46#diff-9fc47c2f5b2f4a7f1883306746ce8fcadab8eb904a6c4526ae5432eba43b3ae8R274-R276

edit:
also adding support to specify the validation order which will help to get rid of this:
https://github.com/omniosorg/zadm/blob/master/lib/Zadm/Validator.pm#L234-L240