### PR TITLE
allow merging the same transformer; default values should not override values that evaluate to false

### DIFF
--- a/lib/Data/Processor.pm
+++ b/lib/Data/Processor.pm
@@ -167,7 +167,6 @@ sub validate_schema {
                 regex => {
                     description => 'should this key be treated as a regular expression?',
                     optional => 1,
-                    default => 0,
                     validator => $bool
                 },
                 value => {
@@ -185,7 +184,6 @@ sub validate_schema {
                 optional => {
                     description => 'is this key optional ?',
                     optional => 1,
-                    default => 0,
                     validator => $bool,
                 },
                 default => {
@@ -195,13 +193,11 @@ sub validate_schema {
                 array => {
                     description => 'is the value of this key expected to be an array? In array mode, value and validator will be applied to each element of the array.',
                     optional => 1,
-                    default => 0,
                     validator => $bool
                 },
                 allow_empty => {
                     description => 'allow empty entries in an array',
                     optional => 1,
-                    default => 0,
                     validator => sub {
                         my ($value, $parent) = @_;
                         return 'allow_empty can only be set for array' if !$parent->{array};

--- a/lib/Data/Processor/PodWriter.pm
+++ b/lib/Data/Processor/PodWriter.pm
@@ -15,7 +15,7 @@ sub pod_write{
         $pod_string .= ": $schema->{$key}->{description}"
             if $schema->{$key}->{description};
         $pod_string .= "\n\nDefault value: $schema->{$key}->{default}"
-            if $schema->{$key}->{default};
+            if defined $schema->{$key}->{default};
         $pod_string .= "\n\n";
         if ($schema->{$key}->{members}){
             $pod_string .= "$key has the following members:\n\n";

--- a/lib/Data/Processor/Validator.pm
+++ b/lib/Data/Processor/Validator.pm
@@ -177,9 +177,9 @@ sub _add_defaults_and_transform {
     my $self = shift;
 
     for my $key (keys %{$self->{schema}}){
-        next unless $self->{schema}->{$key}->{default};
+        next unless defined $self->{schema}->{$key}->{default};
         $self->{data}->{$key} = $self->{schema}->{$key}->{default}
-            unless $self->{data}->{$key};
+            unless defined $self->{data}->{$key};
     }
 
     for my $key (keys %{$self->{data}}){

--- a/t/011_default_values.t
+++ b/t/011_default_values.t
@@ -9,15 +9,46 @@ my $schema = {
     }
 };
 
+my $schema_2 = {
+    key_with_default_value => {
+        default => 0
+    }
+};
+
 my $data = {};
 
+my $data_2 = {
+    key_with_default_value => 0,
+};
+
+my $data_3 = {
+    key_with_default_value => '',
+};
 
 my $p = Data::Processor->new($schema);
 
-my $error_collection = $p->validate($data, verbose=>0);
+my $error_collection = $p->validate($data, verbose => 0);
 
-ok ($data->{key_with_default_value}==42,
+ok ($data->{key_with_default_value} == 42,
     'key_with_default_value 42 inserted');
 
+$error_collection = $p->validate($data_2, verbose => 0);
+
+ok ($data_2->{key_with_default_value} eq '0',
+    'default value not overriding 0');
+
+$error_collection = $p->validate($data_3, verbose => 0);
+
+ok ($data_3->{key_with_default_value} eq '',
+    'default value not overriding empty string');
+
+$p = Data::Processor->new($schema_2);
+
+$data = {};
+
+$error_collection = $p->validate($data, verbose => 0);
+
+ok ($data->{key_with_default_value} eq '0',
+    'key_with_default_value 0 inserted');
 
 done_testing;


### PR DESCRIPTION
This PR contains the following fixes/enhancements:

- Merging schemata where a member has a transformer defined in the "other" schema is not possible. Allow it when both transformers point to the same transformer or just one of them has defined a transformer.
- Merging schemata where both members have the same validator for a member leads to running the validator twice.
- Default values override values that evaluate to false.
- Using values as default values that evaluate to false are ignored.

To verify the changes I added tests that failed before but succeed with the changes applied; additionally i ran the [zadm](https://github.com/omniosorg/zadm) test suite successfully which exercises a big share of `Data::Processor`.